### PR TITLE
Revert changes to the invite link regex pattern

### DIFF
--- a/pyrogram/scaffold.py
+++ b/pyrogram/scaffold.py
@@ -41,8 +41,7 @@ class Scaffold:
 
     PARENT_DIR = Path(sys.argv[0]).parent
 
-    # https://regex101.com/r/pme5ZE/2 Matches both the entire link and the hash itself
-    INVITE_LINK_RE = re.compile(r"^(?:(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/joinchat/))?(?P<hash>[\w-]+)$")
+    INVITE_LINK_RE = re.compile(r"^(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/joinchat/)([\w-]+)$")
     WORKERS = min(32, os.cpu_count() + 4)
     WORKDIR = PARENT_DIR
     CONFIG_FILE = PARENT_DIR / "config.ini"


### PR DESCRIPTION
New invite link methods don't need this and this change was
breaking old code (get_chat, join_chat)