### PR TITLE
Fix renamed raw API function (#810)

### DIFF
--- a/pyrogram/methods/chats/delete_user_history.py
+++ b/pyrogram/methods/chats/delete_user_history.py
@@ -42,9 +42,9 @@ class DeleteUserHistory(Scaffold):
         """
 
         r = await self.send(
-            raw.functions.channels.DeleteUserHistory(
+            raw.functions.channels.DeleteParticipantHistory(
                 channel=await self.resolve_peer(chat_id),
-                user_id=await self.resolve_peer(user_id)
+                participant=await self.resolve_peer(user_id)
             )
         )
 


### PR DESCRIPTION
`raw.functions.channels.DeleteUserHistory` to `raw.functions.channels.DeleteParticipantHistory`