### PR TITLE
Handle the case when default_send_as is None (#842)

### DIFF
--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -320,12 +320,13 @@ class Chat(Object):
 
                 default_send_as = full_chat.default_send_as
 
-                if isinstance(default_send_as, raw.types.PeerUser):
-                    send_as_raw = users[default_send_as.user_id]
-                else:
-                    send_as_raw = chats[default_send_as.channel_id]
-
-                parsed_chat.send_as_chat = Chat._parse_chat(client, send_as_raw)
+                if default_send_as:
+                    if isinstance(default_send_as, raw.types.PeerUser):
+                        send_as_raw = users[default_send_as.user_id]
+                    else:
+                        send_as_raw = chats[default_send_as.channel_id]
+    
+                    parsed_chat.send_as_chat = Chat._parse_chat(client, send_as_raw)
 
             if full_chat.pinned_msg_id:
                 parsed_chat.pinned_message = await client.get_messages(


### PR DESCRIPTION
* fix parsing send_as peer.

* Update chat.py

Co-authored-by: Dan <14043624+delivrance@users.noreply.github.com>